### PR TITLE
Fix Localtime in ErrorHandlingValueReader

### DIFF
--- a/src/EntityFramework/Core/Common/internal/materialization/shaper.cs
+++ b/src/EntityFramework/Core/Common/internal/materialization/shaper.cs
@@ -958,7 +958,7 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
                     var dto = default(DateTimeOffset);
                     DateTimeOffset.TryParse((string)resultObj, out dto);
 
-                    var dateTime = dto.DateTime - dto.Offset;
+                    var dateTime = dto.DateTime + dto.Offset;
                     var offset = dto.Offset;
 
                     var result = new DateTimeOffset(dateTime, offset);


### PR DESCRIPTION
- Missed this one. Changed offset being applied in wrong direction in ErrorHandlingValueReader.
