### PR TITLE
HC-1746 - DateTimeOffset param support in SqlCE

### DIFF
--- a/src/EntityFramework.SqlServerCompact/SqlCeProviderServices.cs
+++ b/src/EntityFramework.SqlServerCompact/SqlCeProviderServices.cs
@@ -616,7 +616,14 @@ namespace System.Data.Entity.SqlServerCompact
                     throw ADP1.NotSupported(EntityRes.GetString(EntityRes.ProviderDoesNotSupportType, "Time"));
 
                 case PrimitiveTypeKind.DateTimeOffset:
-                    throw ADP1.NotSupported(EntityRes.GetString(EntityRes.ProviderDoesNotSupportType, "DateTimeOffset"));
+                    // <<HELM OPS>> The old code just threw an exception here like this:
+                    //
+                    //     throw ADP1.NotSupported(EntityRes.GetString(EntityRes.ProviderDoesNotSupportType, "DateTimeOffset"));
+                    //
+                    // Now it is simply declaring that DateTimeOffset should be treated as NVarChar(40). There are code changes
+                    // elsewhere (also with <<HELM OPS>> annotation) that provide the conversions to and from DateTimeOffset.
+                    size = 40;
+                    return SqlDbType.NVarChar;
 
                 case PrimitiveTypeKind.DateTime:
                     return SqlDbType.DateTime;


### PR DESCRIPTION
The bug was that you could not filter on DateTimeOffset parameters when
using the SqlCe provider. When SqlCeProviderServices encountered a
DateTimeOffset parameter in a filter expression it would simply throw an
excpetion saying that it was not supported. Following the existing
pattern that we established for DateTimeOffset values in SQL CE, I
modified SqlCeProviderServices to treat PrimitiveTypeKind.DateTimeOffset
as VNarChar(40), and I modified DbProviderServices to convert
DateTimeOffset values to UTC strings when it is generating parameters for
the actual SQL query. It will only do this convertion if the value is a
DateTimeOffset and the database field is a string type. Technically this
change is not specific to SQL Compact, so it should mean that in any DB
provider if you somehow find a way to make an expression that compares a
string to a DateTimeOffset it will actually work. This is an acceptable
tradeoff which we could even argue is a feature.
